### PR TITLE
Load tokenizer with `from_pretrained`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ This is an example of how one can use Huggingface model and tokenizers bundled t
 
 ```python
 import tensorflow as tf
-from tftokenizer import TFModel
-from tftokenizers import TFAutoTokenizer
 from transformers import TFAutoModel
+from tftokenizers import TFModel, TFAutoTokenizer
 
 # Load base models from Huggingface
 model_name = "bert-base-cased"
 model = TFAutoModel.from_pretrained(model_name)
 
 # Load converted TF tokenizer
-tokenizer = TFAutoTokenizer(model_name)
+tokenizer = TFAutoTokenizer.from_pretrained(model_name)
 
 # Create a TF Reusable SavedModel
 custom_model = TFModel(model=model, tokenizer=tokenizer)
@@ -38,13 +37,10 @@ s3 = "Hello, world!"
 output = custom_model(tf_string)
 output = custom_model([s1, s2, s3])
 
-# You can also pass arguments, similar to Huggingface tokenizers
+# We can now pass input as tensors
 output = custom_model(
-    [s1, s2, s3],
-    max_length=512,
-    padding="max_length",
+    inputs=tf.constant([s1, s2, s3], dtype=tf.string, name="inputs"),
 )
-print(output)
 
 # Save tokenizer
 saved_name = "reusable_bert_tf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tftokenizers"
-version = "0.1.3"
+version = "0.1.4"
 description = "Use Huggingface Transformer and Tokenizers as Tensorflow Reusable SavedModels."
 authors = ["MarkusSagen <markus.john.sagen@gmail.com>"]
 license = "Apache License 2.0"

--- a/tests/test_tftransformers.py
+++ b/tests/test_tftransformers.py
@@ -1,5 +1,0 @@
-from tftokenizers import __version__
-
-
-def test_version():
-    assert __version__ == "0.1.0"

--- a/tests/test_transformer_models.py
+++ b/tests/test_transformer_models.py
@@ -48,8 +48,6 @@ def test_huggingface_model_with_custom_and_their_tokenizer(hf_tokenizer, model):
     custom_model = TFModel(model=model, tokenizer=custom_tokenizer)
     tf_output = custom_model(
         [s1, s2, s3],
-        padding=PaddingStrategies.MAX_LENGTH,
-        max_length=max_length,
         training=False,
     )
     print(tf_output)  # with `shape=(3, 512, 768)`

--- a/tftokenizers/__init__.py
+++ b/tftokenizers/__init__.py
@@ -1,6 +1,6 @@
 """Use Huggingface Transformer and Tokenizers as Tensorflow Resuable SavedModels."""
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 from .detect import detect_and_load_tokenizer as detect_and_load_tokenizer
 from .detect import find_tf_base_tokenizer as find_tf_base_tokenizer

--- a/tftokenizers/convert.py
+++ b/tftokenizers/convert.py
@@ -1,8 +1,9 @@
 import tensorflow as tf
 import tensorflow_text as text
+from transformers import AutoTokenizer
 
 from tftokenizers.file import get_filename_from_path, get_vocab_from_path, load_json
-from tftokenizers.tokenizer import TFTokenizerBase
+from tftokenizers.tokenizer import TFAutoTokenizer, TFTokenizerBase
 from tftokenizers.types import PaddingStrategies
 
 tf.get_logger().setLevel("ERROR")
@@ -31,9 +32,12 @@ if __name__ == "__main__":
         hf_spec=tokenizer_spec,
         config=config,
     )
+    hf_tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
+    # tokenizer = TFAutoTokenizer("bert-base-uncased")
+    tokenizer = TFAutoTokenizer.from_pretrained("bert-base-uncased")
 
     # # Save tokenizer
-    model_name = "exported_custom_bert_tokenizer"
+    model_name = "exported_custom_bert_tokenizer_auto"
     tf.saved_model.save(tokenizer, model_name)
 
     # # Load tokenizer
@@ -42,9 +46,22 @@ if __name__ == "__main__":
     tokens = tokenizer.tokenize(
         [s1, s2, s3],
         padding=PaddingStrategies.LONGEST,
-        max_length=512,
+        max_length=10,
     )["input_ids"]
     print("Token IDs:\n", tokens.numpy())
 
+    tokens = hf_tokenizer.batch_encode_plus(
+        [s1, s2, s3],
+        padding=PaddingStrategies.LONGEST.value,
+        max_length=10,
+    )
+    print("hf tokens\n", tokens)
+
     tokens = reloaded_tokenizer.tokenize([s1, s2, s3])["input_ids"]
+    print("Token IDs:\n", tokens.numpy())
+    print("")
+
+    tokens = reloaded_tokenizer.tokenize(
+        inputs=tf.constant([s1, s2, s3], dtype=tf.string, name="inputs"),
+    )["input_ids"]
     print("Token IDs:\n", tokens.numpy())

--- a/tftokenizers/main.py
+++ b/tftokenizers/main.py
@@ -26,7 +26,5 @@ if __name__ == "__main__":
     # You can also pass arguments, similar how they are named from Huggingface
     output = custom_model(
         [s1, s2, s3],
-        max_length=512,
-        padding="max_length",
     )
     print(output)

--- a/tftokenizers/model.py
+++ b/tftokenizers/model.py
@@ -8,7 +8,7 @@ from transformers import AutoTokenizer, TFAutoModel
 from transformers.utils.logging import set_verbosity_error
 
 from tftokenizers.file import get_filename_from_path, get_vocab_from_path, load_json
-from tftokenizers.tokenizer import TFTokenizerBase
+from tftokenizers.tokenizer import TFAutoTokenizer, TFTokenizerBase
 from tftokenizers.types import PaddingStrategies
 
 set_verbosity_error()
@@ -24,12 +24,10 @@ class TFModel(keras.layers.Layer):
     def call(
         self,
         inputs,
-        max_length=512,
-        padding: Optional[PaddingStrategies] = None,
         verbose=False,
         training=True,
     ):
-        tokens = self.tokenizer.tokenize(inputs, max_length=max_length, padding=padding)
+        tokens = self.tokenizer.tokenize(inputs=inputs)
         if verbose:
             print(tokens)
 
@@ -66,13 +64,12 @@ if __name__ == "__main__":
         hf_spec=tokenizer_spec,
         config=config,
     )
+    custom_tokenizer = TFAutoTokenizer.from_pretrained("bert-base-uncased")
 
     # Building our custom TF model pipeline
     custom_model = TFModel(model, custom_tokenizer)
     output = custom_model(
         [s1, s2, s3],
-        max_length=max_length,
-        padding=PaddingStrategies.MAX_LENGTH,
     )
 
     # Compare against the Huggingface implementation

--- a/tftokenizers/utils.py
+++ b/tftokenizers/utils.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Tuple
 
 import tensorflow as tf
 
-from tftokenizers.types import TemplateType
+from tftokenizers.types import PaddingStrategies, TemplateType
 
 
 def map_special_tokens_to_ids(
@@ -50,3 +50,20 @@ def to_tensor(x: int) -> tf.Tensor:
 
 def list_to_tensor(lst: List[int]):
     return [to_tensor(num) for num in lst]
+
+
+def set_valid_max_seq_length(
+    desired=None, model_max_length=512, num_max_tokens_in_seq=510
+) -> int:
+    """Calculate and set the maximum allowed sequence length."""
+    min_length = model_max_length - num_max_tokens_in_seq
+    max_length = num_max_tokens_in_seq
+
+    if desired is None or desired > max_length or desired <= min_length:
+        desired = max_length
+    return desired
+
+
+def set_valid_padding(padding: PaddingStrategies) -> PaddingStrategies:
+    padding = padding if padding is not None else PaddingStrategies.LONGEST
+    return padding


### PR DESCRIPTION
* Load tokenizer with `from_pretrained` classmethod
* Remove branching arguments (setting padding option, etc) for custom model, since they can not be used yet when saving adn reloading the model.